### PR TITLE
return filenames from download_eofs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sentineleof",
-    version="0.4.2",
+    version="0.4.3",
     author="Scott Staniewicz",
     author_email="scott.stanie@utexas.com",
     description="Download precise orbit files for Sentinel 1 products",


### PR DESCRIPTION
When calling from python, this lets you more easily use new orbit file that you just downloaded, rather than having to search for it