### PR TITLE
Small improvement so CLI and logging

### DIFF
--- a/eof/__main__.py
+++ b/eof/__main__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+from eof.cli import cli
+
+sys.exit(cli())

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -3,6 +3,7 @@ CLI tool for downloading Sentinel 1 EOF files
 """
 import click
 from eof import download
+from eof import log
 
 
 @click.command()
@@ -43,6 +44,7 @@ def cli(search_path, save_dir, sentinel_file, date, mission):
     Will find both ".SAFE" and ".zip" files matching Sentinel-1 naming convention.
     With no arguments, searches current directory for Sentinel 1 products
     """
+    log._set_logger_handler()
     download.main(
         search_path=search_path,
         save_dir=save_dir,

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -23,7 +23,7 @@ from eof import download
 )
 @click.option(
     "--sentinel-file",
-    type=click.Path(exists=True, file_okay=True, dir_okay=True),
+    type=click.Path(exists=False, file_okay=True, dir_okay=True),
     help="Specify path to download only 1 .EOF for a Sentinel-1 file/folder",
     show_default=True,
 )

--- a/eof/log.py
+++ b/eof/log.py
@@ -12,4 +12,5 @@ def _set_logger_handler(level="INFO"):
 
 
 logger = logging.Logger("sentineleof")
-_set_logger_handler()
+logger.addHandler(logging.NullHandler())
+# _set_logger_handler()


### PR DESCRIPTION
This PR implements 3 main changes:

* add the possibility to run the CLI (also) as follows ``python -m eof``
* do not require the S1 product to be on disk when using the ``--sentinel-file`` parameter (in no case eof access the file)
* do not force the setup of the eof specific log handler allowing the client code to make its own logging configuration (``log._set_logger_handler()`` is now called from the CLI main).
