### PR TITLE
Ensure that EOF files are extracted from the archive to the correct directory

### DIFF
--- a/eof/download.py
+++ b/eof/download.py
@@ -233,9 +233,15 @@ def _download_and_write(mission, dt, save_dir="."):
 
 def _extract_zip(fname_zipped, delete=True):
     # dirname = os.path.dirname(fname_zipped)
+    outdir = os.path.dirname(fname_zipped)
     with ZipFile(fname_zipped, "r") as zip_ref:
         # Extract the .EOF to the same direction as the .zip
-        zip_ref.extractall()
+        for name in zip_ref.namelist():
+            data = zip_ref.read(name)
+            newname = os.path.join(outdir, os.path.basename(name))
+            with open(newname, 'wb') as fd:
+                fd.write(data)
+
     if delete:
         os.remove(fname_zipped)
 


### PR DESCRIPTION
For some strange reason orbit files available at http://step.esa.int/auxdata/orbits/Sentinel-1 are provided as zip archives containing a ``tmp`` folder.
Just using ``zip_ref.extractall()`` to extract them put the orbit file in the ``tmp`` folder ilocated in the current working directory.

The patch changes this behaviour by extracting the desired orbit file in the same directory where the archive is located which IMHO is the expected behaviour (it also honours the ``--save-dir`` CLI parameter).