### PR TITLE
Fix orbit padding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         include:
         - os: windows-latest
           python-version: "3.10"

--- a/eof/scihubclient.py
+++ b/eof/scihubclient.py
@@ -21,7 +21,10 @@ class ValidityError(ValueError):
 
 
 def lastval_cover(
-    t0: datetime.datetime, t1: datetime.datetime, data: Sequence[SentinelOrbit]
+    t0: datetime.datetime,
+    t1: datetime.datetime,
+    data: Sequence[SentinelOrbit],
+    margin: datetime.timedelta = datetime.timedelta(minutes=5),
 ) -> str:
     candidates = [
         item for item in data if item.start_time <= t0 and item.stop_time >= t1
@@ -45,8 +48,13 @@ class ScihubGnssClient:
     T0 = datetime.timedelta(days=1)
     T1 = datetime.timedelta(days=1)
 
-    def __init__(self, user: str = "gnssguest", password: str = "gnssguest",
-                 api_url: str = "https://scihub.copernicus.eu/gnss/", **kwargs):
+    def __init__(
+        self,
+        user: str = "gnssguest",
+        password: str = "gnssguest",
+        api_url: str = "https://scihub.copernicus.eu/gnss/",
+        **kwargs
+    ):
         self._api = SentinelAPI(user=user, password=password, api_url=api_url, **kwargs)
 
     def query_orbit(self, t0, t1, satellite_id: str, product_type: str = "AUX_POEORB"):
@@ -129,7 +137,9 @@ class ScihubGnssClient:
                     product_type="AUX_POEORB",
                 )
                 try:
-                    result = self._select_orbit(products, dt, dt + datetime.timedelta(minutes=1))
+                    result = self._select_orbit(
+                        products, dt, dt + datetime.timedelta(minutes=1)
+                    )
                 except ValidityError:
                     result = None
             else:
@@ -210,7 +220,9 @@ class ASFClient:
             max_saved = max([e.start_time for e in eof_list])
             if max_saved < max_dt:
                 logger.warning("Clearing cached {} EOF list:".format(orbit_type))
-                logger.warning("{} is older than requested {}".format(max_saved, max_dt))
+                logger.warning(
+                    "{} is older than requested {}".format(max_saved, max_dt)
+                )
                 self._clear_cache(orbit_type)
             else:
                 logger.info("Using cached EOF list")

--- a/eof/scihubclient.py
+++ b/eof/scihubclient.py
@@ -27,7 +27,9 @@ def lastval_cover(
     margin: datetime.timedelta = datetime.timedelta(minutes=5),
 ) -> str:
     candidates = [
-        item for item in data if item.start_time <= t0 and item.stop_time >= t1
+        item
+        for item in data
+        if item.start_time <= (t0 - margin) and item.stop_time >= (t1 + margin)
     ]
     if not candidates:
         raise ValidityError(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sentineleof",
-    version="0.6.5",
+    version="0.7.0",
     author="Scott Staniewicz",
     author_email="scott.stanie@gmail.com",
     description="Download precise orbit files for Sentinel 1 products",


### PR DESCRIPTION
Add a buffer of 5 minutes to SLC start/end times, fixes a bug found by @vbrancato


Before:

```python

print(parsers.Sentinel('S1A_IW_SLC__1SDV_20210601T225942_20210601T230009_038153_0480C6_BB00'))
Sentinel(
    filename='S1A_IW_SLC__1SDV_20210601T225942_20210601T230009_038153_0480C6_BB00',
    start_time=datetime.datetime(2021, 6, 1, 22, 59, 42, tzinfo=datetime.timezone.utc),
    stop_time=datetime.datetime(2021, 6, 1, 23, 0, 9, tzinfo=datetime.timezone.utc),
    relative_orbit=106,
    polarization='DV',
    mission='S1A'
)
# [07/13 17:30:19] [INFO download.py] Downloading precise orbits for S1A on 2021-06-01
Downloading S1A_OPER_AUX_POEORB_OPOD_20210622T121821_V20210601T225942_20210603T005942.EOF: 100%
print(parsers.SentinelOrbit("S1A_OPER_AUX_POEORB_OPOD_20210622T121821_V20210601T225942_20210603T005942.EOF"))
SentinelOrbit(
    filename='S1A_OPER_AUX_POEORB_OPOD_20210622T121821_V20210601T225942_20210603T005942.EOF',
    orbit_type='precise',
    start_time=datetime.datetime(2021, 6, 1, 22, 59, 42, tzinfo=datetime.timezone.utc),
    stop_time=datetime.datetime(2021, 6, 3, 0, 59, 42, tzinfo=datetime.timezone.utc)
)

```


after
```python
# Downloading S1A_OPER_AUX_POEORB_OPOD_20210621T121719_V20210531T225942_20210602T005942.EOF: 100%|
In [92]: print(parsers.SentinelOrbit("S1A_OPER_AUX_POEORB_OPOD_20210621T121719_V20210531T225942_20210602T005942.EOF"))
SentinelOrbit(
    filename='S1A_OPER_AUX_POEORB_OPOD_20210621T121719_V20210531T225942_20210602T005942.EOF',
    orbit_type='precise',
    start_time=datetime.datetime(2021, 5, 31, 22, 59, 42, tzinfo=datetime.timezone.utc),
    stop_time=datetime.datetime(2021, 6, 2, 0, 59, 42, tzinfo=datetime.timezone.utc)
)
```