### PR TITLE
Fix 401 error (ASF) and skip SciHub

### DIFF
--- a/eof/cli.py
+++ b/eof/cli.py
@@ -2,8 +2,8 @@
 CLI tool for downloading Sentinel 1 EOF files
 """
 import click
-from eof import download
-from eof import log
+
+from eof import download, log
 
 
 @click.command()

--- a/eof/download.py
+++ b/eof/download.py
@@ -81,7 +81,7 @@ def download_eofs(orbit_dts=None, missions=None, sentinel_file=None, save_dir=".
             query = client.query_orbit_by_dt(orbit_dts, missions, orbit_type=orbit_type)
 
         if query:
-            print("Attempting download from SciHub")
+            logger.info("Attempting download from SciHub")
             result = client.download_all(query, directory_path=save_dir)
             filenames.extend(
                 item['path'] for item in result.downloaded.values()

--- a/eof/download.py
+++ b/eof/download.py
@@ -124,7 +124,6 @@ def _download_and_write(url, save_dir=".", asf_user="", asf_password=""):
     Returns:
         list[str]: Filenames to which the orbit files have been saved
     """
-        
     fname = os.path.join(save_dir, url.split("/")[-1])
     if os.path.isfile(fname):
         logger.info("%s already exists, skipping download.", url)

--- a/eof/download.py
+++ b/eof/download.py
@@ -35,8 +35,16 @@ from .log import logger
 MAX_WORKERS = 6  # workers to download in parallel (for ASF backup)
 
 
-def download_eofs(orbit_dts=None, missions=None, sentinel_file=None, save_dir=".",
-                  orbit_type="precise", force_asf=False, asf_user="", asf_password=""):
+def download_eofs(
+    orbit_dts=None,
+    missions=None,
+    sentinel_file=None,
+    save_dir=".",
+    orbit_type="precise",
+    force_asf=False,
+    asf_user="",
+    asf_password="",
+):
     """Downloads and saves EOF files for specific dates
 
     Args:
@@ -83,9 +91,7 @@ def download_eofs(orbit_dts=None, missions=None, sentinel_file=None, save_dir=".
         if query:
             logger.info("Attempting download from SciHub")
             result = client.download_all(query, directory_path=save_dir)
-            filenames.extend(
-                item['path'] for item in result.downloaded.values()
-            )
+            filenames.extend(item["path"] for item in result.downloaded.values())
             scihub_successful = True
 
     # For failures from scihub, try ASF
@@ -130,8 +136,12 @@ def _download_and_write(url, save_dir=".", asf_user="", asf_password=""):
 
     logger.info("Downloading %s", url)
     # Fix URL
-    if 's1qc.asf.alaska.edu' in url:
-        url = 'https://urs.earthdata.nasa.gov/oauth/authorize?response_type=code&client_id=BO_n7nTIlMljdvU6kRRB3g&redirect_uri=https://auth.asf.alaska.edu/login&state='+url+'&app_type=401'
+    if "s1qc.asf.alaska.edu" in url:
+        url = (
+            "https://urs.earthdata.nasa.gov/oauth/authorize?response_type=code&client_id=BO_n7nTIlMljdvU6kRRB3g&redirect_uri=https://auth.asf.alaska.edu/login&state="
+            + url
+            + "&app_type=401"
+        )
     # Add credentials
     response = requests.get(url, auth=(asf_user, asf_password))
     response.raise_for_status()
@@ -216,14 +226,24 @@ def find_scenes_to_download(search_path="./", save_dir="./"):
     return orbit_dts, missions
 
 
-def main(search_path=".", save_dir=",", sentinel_file=None, mission=None, date=None, orbit_type="precise", force_asf=False, asf_user="", asf_password=""):
+def main(
+    search_path=".",
+    save_dir=",",
+    sentinel_file=None,
+    mission=None,
+    date=None,
+    orbit_type="precise",
+    force_asf=False,
+    asf_user="",
+    asf_password="",
+):
     """Function used for entry point to download eofs"""
 
     if not os.path.exists(save_dir):
         logger.info("Creating directory for output: %s", save_dir)
         os.mkdir(save_dir)
 
-    if (mission and not date):
+    if mission and not date:
         raise ValueError("Must specify date if providing mission.")
 
     if sentinel_file:
@@ -251,5 +271,5 @@ def main(search_path=".", save_dir=",", sentinel_file=None, mission=None, date=N
         orbit_type=orbit_type,
         force_asf=force_asf,
         asf_user=asf_user,
-        asf_password=asf_password
+        asf_password=asf_password,
     )

--- a/eof/download.py
+++ b/eof/download.py
@@ -90,7 +90,6 @@ def download_eofs(orbit_dts=None, missions=None, sentinel_file=None, save_dir=".
 
     # For failures from scihub, try ASF
     if not scihub_successful:
-        print("Attempting download from ASF")
         logger.warning("Scihub failed, trying ASF")
         asfclient = ASFClient()
         urls = asfclient.get_download_urls(orbit_dts, missions, orbit_type=orbit_type)

--- a/eof/download.py
+++ b/eof/download.py
@@ -97,7 +97,9 @@ def download_eofs(orbit_dts=None, missions=None, sentinel_file=None, save_dir=".
         # Download and save all links in parallel
         pool = ThreadPool(processes=MAX_WORKERS)
         result_url_dict = {
-            pool.apply_async(_download_and_write, args=[url, save_dir, user, password]): url
+            pool.apply_async(
+                _download_and_write, args=[url, save_dir, asf_user, asf_password]
+            ): url
             for url in urls
         }
 

--- a/eof/download.py
+++ b/eof/download.py
@@ -132,7 +132,7 @@ def _download_and_write(url, save_dir=".", asf_user="", asf_password=""):
     logger.info("Downloading %s", url)
     # Fix URL
     if 's1qc.asf.alaska.edu' in url:
-        url='https://urs.earthdata.nasa.gov/oauth/authorize?response_type=code&client_id=BO_n7nTIlMljdvU6kRRB3g&redirect_uri=https://auth.asf.alaska.edu/login&state='+url+'&app_type=401'
+        url = 'https://urs.earthdata.nasa.gov/oauth/authorize?response_type=code&client_id=BO_n7nTIlMljdvU6kRRB3g&redirect_uri=https://auth.asf.alaska.edu/login&state='+url+'&app_type=401'
     # Add credentials
     response = requests.get(url, auth=(asf_user, asf_password))
     response.raise_for_status()

--- a/eof/tests/test_eof.py
+++ b/eof/tests/test_eof.py
@@ -160,4 +160,7 @@ class TestEOF(unittest.TestCase):
             sentinel_file=None,
             save_dir=",",
             orbit_type="precise",
+            force_asf=False,
+            asf_user="",
+            asf_password="",
         )


### PR DESCRIPTION
Fixed an error where downloading from ASF would cause a 401 authentication error.

Added option to skip SciHub and force ASF client.