### PR TITLE
Pad orbit search by one orbit period

### DIFF
--- a/eof/download.py
+++ b/eof/download.py
@@ -234,7 +234,7 @@ def main(search_path=".", save_dir=",", sentinel_file=None, mission=None, date=N
             logger.info(
                 "No Sentinel products found in directory %s, exiting", search_path
             )
-            return 0
+            return []
 
     return download_eofs(
         orbit_dts=orbit_dts,

--- a/eof/scihubclient.py
+++ b/eof/scihubclient.py
@@ -1,19 +1,17 @@
 """sentinelsat based client to get orbit files form scihub.copernicu.eu."""
 
-import os
-import logging
-import requests
 import datetime
 import operator
+import os
 from typing import Sequence
 
-from .products import SentinelOrbit, Sentinel as S1Product
-
+import requests
 from sentinelsat import SentinelAPI
 from sentinelsat.exceptions import ServerError
 
-# logger = logging.getLogger(__name__)
 from .log import logger
+from .products import Sentinel as S1Product
+from .products import SentinelOrbit
 
 
 class ValidityError(ValueError):

--- a/eof/scihubclient.py
+++ b/eof/scihubclient.py
@@ -147,11 +147,7 @@ class ScihubGnssClient:
                     product_type="AUX_POEORB",
                 )
                 try:
-                    result = self._select_orbit(
-                        products,
-                        dt,
-                        dt + timedelta(minutes=1),
-                    )
+                    result = self._select_orbit(products, dt, dt + timedelta(minutes=1))
                 except ValidityError:
                     result = None
             else:

--- a/eof/scihubclient.py
+++ b/eof/scihubclient.py
@@ -1,8 +1,9 @@
 """sentinelsat based client to get orbit files form scihub.copernicu.eu."""
+from __future__ import annotations
 
-import datetime
 import operator
 import os
+from datetime import datetime, timedelta
 from typing import Sequence
 
 import requests
@@ -13,21 +14,27 @@ from .log import logger
 from .products import Sentinel as S1Product
 from .products import SentinelOrbit
 
+T_ORBIT = (12 * 86400.0) / 175.0
+"""Orbital period of Sentinel-1 in seconds"""
+
 
 class ValidityError(ValueError):
     pass
 
 
 def lastval_cover(
-    t0: datetime.datetime,
-    t1: datetime.datetime,
+    t0: datetime,
+    t1: datetime,
     data: Sequence[SentinelOrbit],
-    margin: datetime.timedelta = datetime.timedelta(minutes=5),
 ) -> str:
+    # Using a start margin of > 1 orbit so that the start of the orbit file will
+    # cover the ascending node crossing of the acquisition
+    margin0 = timedelta(seconds=T_ORBIT + 60)
+    margin1 = timedelta(minutes=5)
     candidates = [
         item
         for item in data
-        if item.start_time <= (t0 - margin) and item.stop_time >= (t1 + margin)
+        if item.start_time <= (t0 - margin0) and item.stop_time >= (t1 + margin1)
     ]
     if not candidates:
         raise ValidityError(
@@ -45,19 +52,21 @@ class OrbitSelectionError(RuntimeError):
 
 
 class ScihubGnssClient:
-    T0 = datetime.timedelta(days=1)
-    T1 = datetime.timedelta(days=1)
+    T0 = timedelta(days=1)
+    T1 = timedelta(days=1)
 
     def __init__(
         self,
         user: str = "gnssguest",
         password: str = "gnssguest",
         api_url: str = "https://scihub.copernicus.eu/gnss/",
-        **kwargs
+        **kwargs,
     ):
         self._api = SentinelAPI(user=user, password=password, api_url=api_url, **kwargs)
 
-    def query_orbit(self, t0, t1, satellite_id: str, product_type: str = "AUX_POEORB"):
+    def query_orbit(
+        self, t0, t1, satellite_id: str, product_type: str = "AUX_POEORB"
+    ) -> dict[str, dict]:
         assert satellite_id in {"S1A", "S1B"}
         assert product_type in {"AUX_POEORB", "AUX_RESORB"}
 
@@ -76,7 +85,7 @@ class ScihubGnssClient:
         return products
 
     @staticmethod
-    def _select_orbit(products, t0, t1):
+    def _select_orbit(products: dict[str, dict], t0: datetime, t1: datetime):
         if not products:
             return {}
         orbit_products = [p["identifier"] for p in products.values()]
@@ -88,8 +97,8 @@ class ScihubGnssClient:
         self,
         product,
         orbit_type: str = "precise",
-        t0_margin: datetime.timedelta = T0,
-        t1_margin: datetime.timedelta = T1,
+        t0_margin: timedelta = T0,
+        t1_margin: timedelta = T1,
     ):
         if isinstance(product, str):
             product = S1Product(product)
@@ -107,18 +116,19 @@ class ScihubGnssClient:
         orbit_dts,
         missions,
         orbit_type: str = "precise",
-        t0_margin: datetime.timedelta = T0,
-        t1_margin: datetime.timedelta = T1,
+        t0_margin: timedelta = T0,
+        t1_margin: timedelta = T1,
     ):
         """Query the Scihub api for product info for the specified missions/orbit_dts.
 
         Args:
-            orbit_dts (list[datetime.datetime]): list of orbit datetimes
+            orbit_dts (list[datetime]): list of orbit datetimes
             missions (list[str]): list of mission names
-            orbit_type (str, optional): Type of orbit to prefer in search. Defaults to "precise".
-            t0_margin (datetime.timedelta, optional): Margin used in searching for early bound
+            orbit_type (str, optional): Type of orbit to prefer in search.
+                Defaults to "precise".
+            t0_margin (timedelta, optional): Margin used in searching for early bound
                 for orbit.  Defaults to 1 day.
-            t1_margin (datetime.timedelta, optional): Margin used in searching for late bound
+            t1_margin (timedelta, optional): Margin used in searching for late bound
                 for orbit.  Defaults to 1 day.
 
         Returns:
@@ -128,7 +138,7 @@ class ScihubGnssClient:
         query = {}
         for dt, mission in zip(orbit_dts, missions):
             found_result = False
-            # Only check for previse orbits if that is what we want
+            # Only check for precise orbits if that is what we want
             if orbit_type == "precise":
                 products = self.query_orbit(
                     dt - t0_margin,
@@ -138,7 +148,9 @@ class ScihubGnssClient:
                 )
                 try:
                     result = self._select_orbit(
-                        products, dt, dt + datetime.timedelta(minutes=1)
+                        products,
+                        dt,
+                        dt + timedelta(minutes=1),
                     )
                 except ValidityError:
                     result = None
@@ -151,13 +163,18 @@ class ScihubGnssClient:
             else:
                 # try with RESORB
                 products = self.query_orbit(
-                    dt - datetime.timedelta(hours=1),
-                    dt + datetime.timedelta(hours=1),
+                    dt - timedelta(hours=2),
+                    dt + timedelta(hours=2),
                     mission,
                     product_type="AUX_RESORB",
                 )
                 result = (
-                    self._select_orbit(products, dt, dt + datetime.timedelta(minutes=1))
+                    self._select_orbit(
+                        products,
+                        dt,
+                        dt + timedelta(minutes=1),
+                        orbit_type=orbit_type,
+                    )
                     if products
                     else None
                 )
@@ -244,7 +261,7 @@ class ASFClient:
         Args:
             dt (datetime): requested
         Args:
-            orbit_dts (list[str] or list[datetime.datetime]): datetime for orbit coverage
+            orbit_dts (list[str] or list[datetime]): datetime for orbit coverage
             missions (list[str]): specify S1A or S1B
 
         Returns:
@@ -308,7 +325,7 @@ class ASFClient:
     @staticmethod
     def get_cache_dir():
         """Find location of directory to store .hgt downloads
-        Assuming linux, uses ~/.cache/sardem/
+        Assuming linux, uses ~/.cache/sentineleof/
         """
         path = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
         path = os.path.join(path, "sentineleof")  # Make subfolder for our downloads

--- a/eof/tests/test_eof.py
+++ b/eof/tests/test_eof.py
@@ -1,163 +1,49 @@
-import unittest
-import tempfile
-import shutil
 import datetime
-import os
-import responses
 
-from unittest import mock
+import pytest
+
 from eof import download
 
 
-class TestEOF(unittest.TestCase):
-    def setUp(self):
-        self.empty_api_search = {"count": 0}
-        self.sample_api_search = {
-            "count": 1,
-            "next": None,
-            "previous": None,
-            "results": [
-                {
-                    "creation_date": "2018-05-22T12:07:30",
-                    "footprint": None,
-                    "hash": "43ca6cd1bdc17a740953ab15da08ddaead6c23d3",
-                    "metadata_date": "2018-06-19T13:16:41.130580",
-                    "physical_name": "S1A_OPER_AUX_POEORB_OPOD_20180522T120730_V20180501T225942_20180503T005942.EOF",
-                    "product_name": "S1A_OPER_AUX_POEORB_OPOD_20180522T120730_V20180501T225942_20180503T005942",
-                    "product_type": "AUX_POEORB",
-                    "remote_url": "http://aux.sentinel1.eo.esa.int/POEORB/2018/05/22/S1A_OPER_AUX_POEORB_OPOD_20180522T120730_V20180501T225942_20180503T005942.EOF",  # noqa
-                    "size": 4410148,
-                    "uuid": "a758ad6d-b718-4dff-a1b2-822874ca4017",
-                    "validity_start": "2018-05-01T22:59:42",
-                    "validity_stop": "2018-05-03T00:59:42",
-                }
-            ],
-        }
-        self.sample_eof = (
-            """<?xml version="1.0" ?><Earth_Explorer_File></Earth_Explorer_File>"""
+def test_find_scenes_to_download(tmpdir):
+    with tmpdir.as_cwd():
+        name1 = (
+            "S1A_IW_SLC__1SDV_20180420T043026_20180420T043054_021546_025211_81BE.zip"
         )
-
-    # @responses.activate
-    # def test_eof_list(self):
-    #     responses.add(
-    #         responses.GET,
-    #         'https://qc.sentinel1.eo.esa.int/api/v1/?product_type=AUX_POEORB&sentinel1__mission=S1A&validity_start__lt=2018-05-01T23:58:00&validity_stop__gt=2018-05-02T00:02:00',  # noqa
-    #         json=self.sample_api_search,
-    #         status=200)
-
-    #     test_date = datetime.datetime(2018, 5, 2)
-    #     result_list = download.eof_list(test_date, 'S1A')
-    #     expected = (
-    #         [
-    #             'http://aux.sentinel1.eo.esa.int/POEORB/2018/05/22/S1A_OPER_AUX_POEORB_OPOD_20180522T120730_V20180501T225942_20180503T005942.EOF'  # noqa
-    #         ],
-    #         'POEORB')
-    #     self.assertEqual(result_list, expected)
-
-    # @responses.activate
-    # def test_eof_list_empty(self):
-    #     responses.add(
-    #         responses.GET,
-    #         'https://qc.sentinel1.eo.esa.int/api/v1/?product_type=AUX_POEORB&sentinel1__mission=S1A&validity_start__lt=2018-05-01T23:58:00&validity_stop__gt=2018-05-02T00:02:00',  # noqa
-    #         json=self.empty_api_search,
-    #         status=200)
-    #     responses.add(
-    #         responses.GET,
-    #         'https://qc.sentinel1.eo.esa.int/api/v1/?product_type=AUX_RESORB&sentinel1__mission=S1A&validity_start__lt=2018-05-01T23:58:00&validity_stop__gt=2018-05-02T00:02:00',  # noqa
-    #         json=self.empty_api_search,
-    #         status=200)
-
-    #     test_date = datetime.datetime(2018, 5, 2)
-    #     self.assertRaises(ValueError, download.eof_list, test_date, 'S1A')
-    #     self.assertEqual(download._download_and_write('S1A', test_date), None)
-
-    def test_find_scenes_to_download(self):
-        try:
-            temp_dir = tempfile.mkdtemp()
-            name1 = os.path.join(
-                temp_dir,
-                "S1A_IW_SLC__1SDV_20180420T043026_20180420T043054_021546_025211_81BE.zip",
-            )
-            name2 = os.path.join(
-                temp_dir,
-                "S1B_IW_SLC__1SDV_20180502T043026_20180502T043054_021721_025793_5C18.zip",
-            )
-            open(name1, "w").close()
-            open(name2, "w").close()
-            orbit_dates, missions = download.find_scenes_to_download(
-                search_path=temp_dir
-            )
-
-            self.assertEqual(
-                sorted(orbit_dates),
-                [
-                    datetime.datetime(2018, 4, 20, 4, 30, 26),
-                    datetime.datetime(2018, 5, 2, 4, 30, 26),
-                ],
-            )
-
-            self.assertEqual(sorted(missions), ["S1A", "S1B"])
-        finally:
-            # Clean up temp dir
-            shutil.rmtree(temp_dir)
-
-    def test_download_eofs_errors(self):
-        orbit_dates = [datetime.datetime(2018, 5, 2, 4, 30, 26)]
-        self.assertRaises(
-            ValueError, download.download_eofs, orbit_dates, missions=["BadMissionStr"]
+        name2 = (
+            "S1B_IW_SLC__1SDV_20180502T043026_20180502T043054_021721_025793_5C18.zip"
         )
-        # More missions for dates
-        self.assertRaises(
-            ValueError, download.download_eofs, orbit_dates, missions=["S1A", "S1B"]
-        )
+        open(name1, "w").close()
+        open(name2, "w").close()
+        orbit_dates, missions = download.find_scenes_to_download(search_path=".")
 
-    # @responses.activate
-    # def test_download_eofs(self):
-    #     # Mock the date search url
-    #     responses.add(
-    #         responses.GET,
-    #         "https://qc.sentinel1.eo.esa.int/api/v1/?product_type=AUX_POEORB&sentinel1__mission=None&validity_start__lt=2018-05-02T04:28:26&validity_stop__gt=2018-05-02T04:32:26",  # noqa
-    #         json=self.sample_api_search,
-    #         status=200,
-    #     )
+        assert sorted(orbit_dates) == [
+            datetime.datetime(2018, 4, 20, 4, 30, 26),
+            datetime.datetime(2018, 5, 2, 4, 30, 26),
+        ]
 
-    #     # Also mock the EOF download url
-    #     eof_url = "http://aux.sentinel1.eo.esa.int/POEORB/2018/05/22/S1A_OPER_AUX_POEORB_OPOD_20180522T120730_V20180501T225942_20180503T005942.EOF"  # noqa
-    #     responses.add(responses.GET, eof_url, body=self.sample_eof, status=200)
+        assert sorted(missions) == ["S1A", "S1B"]
 
-    #     eof_name = eof_url.split("/")[-1]
-    #     orbit_dates = [datetime.datetime(2018, 5, 2, 4, 30, 26)]
-    #     try:
-    #         temp_dir = tempfile.mkdtemp()
-    #         eof_path = os.path.join(temp_dir, eof_name)
-    #         self.assertFalse(os.path.exists(eof_path))
 
-    #         download.download_eofs(orbit_dates, save_dir=temp_dir)
-    #         self.assertTrue(os.path.exists(eof_path))
+def test_download_eofs_errors():
+    orbit_dates = [datetime.datetime(2018, 5, 2, 4, 30, 26)]
+    with pytest.raises(ValueError):
+        download.download_eofs(orbit_dates, missions=["BadMissionStr"])
+    # More missions for dates
+    with pytest.raises(ValueError):
+        download.download_eofs(orbit_dates, missions=["S1A", "S1B"])
 
-    #         # Now read the file and make sure it's the same
-    #         with open(eof_path) as f:
-    #             eof_contents = f.read()
-    #         self.assertEqual(eof_contents, self.sample_eof)
-    #     finally:
-    #         shutil.rmtree(temp_dir)
 
-    def test_main_nothing_found(self):
-        # Test "no sentinel products found"
-        self.assertEqual(download.main(search_path="/notreal"), 0)
+def test_main_nothing_found():
+    # Test "no sentinel products found"
+    assert download.main(search_path="/notreal") == []
 
-    def test_main_error_args(self):
-        self.assertRaises(
-            ValueError, download.main, search_path="/notreal", mission="S1A"
-        )
 
-    @mock.patch("eof.download.download_eofs")
-    def test_mission(self, download_eofs):
+def test_main_error_args():
+    with pytest.raises(ValueError):
+        download.main(search_path="/notreal", mission="S1A")
+
+
+def test_mission(tmpdir):
+    with tmpdir.as_cwd():
         download.main(mission="S1A", date="20200101")
-        download_eofs.assert_called_once_with(
-            missions=["S1A"],
-            orbit_dts=["20200101"],
-            sentinel_file=None,
-            save_dir=",",
-            orbit_type="precise",
-        )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,7 @@
-nose
+pytest
 cython
 twine
 coveralls
-responses
-mock
 sphinx
 m2r
 sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sentineleof",
-    version="0.7.0",
+    version="0.8.0",
     author="Scott Staniewicz",
     author_email="scott.stanie@gmail.com",
     description="Download precise orbit files for Sentinel 1 products",


### PR DESCRIPTION
To match the `s1reader` search window, make sure we pick an orbit that starts at least ~100 minutes before the acquisition time:

https://github.com/isce-framework/s1-reader/blob/559f026e5a47f81e010a0bc47d73dc15afc0b1bd/src/s1reader/s1_orbit.py#L22

This is used to determine the Burst ID for any sentinel product. We need the precise orbit file, since occasionally the metadata is incorrect because it comes from imprecise predicted orbits