### PR TITLE
Smaller orbit padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.swp
 *.vscode
+.DS_Store
 
 # Don't add huge DEM data files
 *.hgt

--- a/eof/products.py
+++ b/eof/products.py
@@ -71,7 +71,7 @@ class Base(object):
         if not self.FILE_REGEX:
             raise NotImplementedError("Must define class FILE_REGEX to parse")
 
-        match = re.search(self.FILE_REGEX, self.filename)
+        match = re.search(self.FILE_REGEX, str(self.filename))
         if not match:
             raise ValueError(
                 "Invalid {} filename: {}".format(self.__class__.__name__, self.filename)

--- a/eof/products.py
+++ b/eof/products.py
@@ -77,17 +77,20 @@ class Base(object):
                 "Invalid {} filename: {}".format(self.__class__.__name__, self.filename)
             )
         else:
-            return match.groups()
+            return match.groupdict()
 
     @property
     def field_meanings(self):
         """List the fields returned by full_parse()"""
-        return self._FIELD_MEANINGS
+        return self.full_parse().keys()
 
     def _get_field(self, fieldname):
         """Pick a specific field based on its name"""
-        idx = self.field_meanings.index(fieldname)
-        return self.full_parse()[idx]
+        return self.full_parse()[fieldname]
+
+    def __getitem__(self, item):
+        """Access properties with uavsar[item] syntax"""
+        return self._get_field(item)
 
 
 class Sentinel(Base):
@@ -125,21 +128,20 @@ class Sentinel(Base):
         filename (str) name of the sentinel data product
     """
 
-    FILE_REGEX = r"(S1A|S1B)_([\w\d]{2})_([\w_]{3})([FHM_])_([012])S([SDHV]{2})_([T\d]{15})_([T\d]{15})_(\d{6})_([\d\w]{6})_([\d\w]{4})"
-    TIME_FMT = "%Y%m%dT%H%M%S"
-    _FIELD_MEANINGS = (
-        "mission",
-        "beam",
-        "product type",
-        "resolution class",
-        "product level",
-        "polarization",
-        "start datetime",
-        "stop datetime",
-        "orbit number",
-        "data-take identified",
-        "product unique id",
+    FILE_REGEX = re.compile(
+        r"(?P<mission>S1A|S1B)_"
+        r"(?P<beam>[\w\d]{2})_"
+        r"(?P<product_type>[\w_]{3})"
+        r"(?P<resolution_class>[FHM_])_"
+        r"(?P<product_level>[012])S"
+        r"(?P<polarization>[SDHV]{2})_"
+        r"(?P<start_datetime>[T\d]{15})_"
+        r"(?P<stop_datetime>[T\d]{15})_"
+        r"(?P<orbit_number>\d{6})_"
+        r"(?P<datetake_identifier>[\d\w]{6})_"
+        r"(?P<unique_id>[\d\w]{4})"
     )
+    TIME_FMT = "%Y%m%dT%H%M%S"
 
     def __init__(self, filename, **kwargs):
         super(Sentinel, self).__init__(filename, **kwargs)
@@ -170,7 +172,7 @@ class Sentinel(Base):
             >>> print(s.start_time)
             2018-04-08 04:30:25
         """
-        start_time_str = self._get_field("start datetime")
+        start_time_str = self._get_field("start_datetime")
         return datetime.strptime(start_time_str, self.TIME_FMT)
 
     @property
@@ -182,7 +184,7 @@ class Sentinel(Base):
             >>> print(s.stop_time)
             2018-04-08 04:30:53
         """
-        stop_time_str = self._get_field("stop datetime")
+        stop_time_str = self._get_field("stop_datetime")
         return datetime.strptime(stop_time_str, self.TIME_FMT)
 
     @property
@@ -205,7 +207,7 @@ class Sentinel(Base):
             >>> print(s.product_type)
             SLC
         """
-        return self._get_field("product type")
+        return self._get_field("product_type")
 
     @property
     def level(self):
@@ -232,7 +234,7 @@ class Sentinel(Base):
             >>> print(s.absolute_orbit)
             21371
         """
-        return int(self._get_field("orbit number"))
+        return int(self._get_field("orbit_number"))
 
     @property
     def relative_orbit(self):
@@ -262,7 +264,7 @@ class Sentinel(Base):
     @property
     def product_uid(self):
         """Unique identifier of product (last 4 of filename)"""
-        return self._get_field("product unique id")
+        return self._get_field("unique_id")
 
     @property
     def date(self):
@@ -305,17 +307,13 @@ class SentinelOrbit(Base):
     Attributes:
         filename (str) name of the sentinel data product
     """
-
-    FILE_REGEX = (
-        r"(S1A|S1B)_OPER_AUX_([\w_]{6})_OPOD_([T\d]{15})_V([T\d]{15})_([T\d]{15})"
-    )
     TIME_FMT = "%Y%m%dT%H%M%S"
-    _FIELD_MEANINGS = (
-        "mission",
-        "orbit type",
-        "created datetime",
-        "start datetime",
-        "stop datetime",
+    FILE_REGEX = (
+        r"(?P<mission>S1A|S1B)_OPER_AUX_"
+        r"(?P<orbit_type>[\w_]{6})_OPOD_"
+        r"(?P<created_datetime>[T\d]{15})_"
+        r"V(?P<start_datetime>[T\d]{15})_"
+        r"(?P<stop_datetime>[T\d]{15})"
     )
 
     def __init__(self, filename, **kwargs):
@@ -361,7 +359,7 @@ class SentinelOrbit(Base):
             >>> print(s.start_time)
             2019-12-31 22:59:42
         """
-        start_time_str = self._get_field("start datetime")
+        start_time_str = self._get_field("start_datetime")
         return datetime.strptime(start_time_str, self.TIME_FMT)
 
     @property
@@ -373,7 +371,7 @@ class SentinelOrbit(Base):
             >>> print(s.stop_time)
             2020-01-02 00:59:42
         """
-        stop_time_str = self._get_field("stop datetime")
+        stop_time_str = self._get_field("stop_datetime")
         return datetime.strptime(stop_time_str, self.TIME_FMT)
 
     @property
@@ -385,12 +383,12 @@ class SentinelOrbit(Base):
             >>> print(s.created_time)
             2020-01-21 12:06:54
         """
-        stop_time_str = self._get_field("created datetime")
+        stop_time_str = self._get_field("created_datetime")
         return datetime.strptime(stop_time_str, self.TIME_FMT)
 
     @property
     def orbit_type(self):
-        """Type of orbit file (previse, restituted)
+        """Type of orbit file (e.g precise, restituted)
 
         Example:
         >>> s = SentinelOrbit('S1A_OPER_AUX_POEORB_OPOD_20200121T120654_V20191231T225942_20200102T005942.EOF')
@@ -400,7 +398,7 @@ class SentinelOrbit(Base):
         >>> print(s.orbit_type)
         restituted
         """
-        o = self._get_field("orbit type")
+        o = self._get_field("orbit_type")
         if o == "POEORB":
             return "precise"
         elif o == "RESORB":

--- a/eof/scihubclient.py
+++ b/eof/scihubclient.py
@@ -156,7 +156,7 @@ class ScihubGnssClient:
                         products,
                         dt,
                         dt + timedelta(minutes=1),
-                        margin0=timedelta(T_ORBIT + 60),
+                        margin0=timedelta(seconds=T_ORBIT + 60),
                     )
                 except ValidityError:
                     result = None
@@ -179,7 +179,7 @@ class ScihubGnssClient:
                         products,
                         dt,
                         dt + timedelta(minutes=1),
-                        margin0=timedelta(T_ORBIT - 1),
+                        margin0=timedelta(seconds=T_ORBIT - 1),
                     )
                     if products
                     else None

--- a/eof/scihubclient.py
+++ b/eof/scihubclient.py
@@ -13,6 +13,8 @@ from sentinelsat.exceptions import ServerError
 from .log import logger
 from .products import Sentinel as S1Product
 from .products import SentinelOrbit
+from .parsing import EOFLinkFinder
+
 
 T_ORBIT = (12 * 86400.0) / 175.0
 """Orbital period of Sentinel-1 in seconds"""
@@ -229,8 +231,6 @@ class ASFClient:
 
     def get_full_eof_list(self, orbit_type="precise", max_dt=None):
         """Get the list of orbit files from the ASF server."""
-        from .parsing import EOFLinkFinder
-
         if orbit_type not in self.urls.keys():
             raise ValueError("Unknown orbit type: {}".format(orbit_type))
 
@@ -306,6 +306,7 @@ class ASFClient:
     def _get_cached_filenames(self, orbit_type="precise"):
         """Get the cache path for the ASF orbit files."""
         filepath = self._get_filename_cache_path(orbit_type)
+        print(f"{filepath = }")
         if os.path.exists(filepath):
             with open(filepath, "r") as f:
                 return [SentinelOrbit(f) for f in f.read().splitlines()]
@@ -335,6 +336,7 @@ class ASFClient:
         """
         path = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
         path = os.path.join(path, "sentineleof")  # Make subfolder for our downloads
+        print(path)
         if not os.path.exists(path):
             os.makedirs(path)
         return path

--- a/eof/tests/test_products.py
+++ b/eof/tests/test_products.py
@@ -1,0 +1,30 @@
+from eof.products import Sentinel, SentinelOrbit
+from datetime import datetime
+
+
+def test_sentinel():
+    p = Sentinel(
+        "S1A_IW_SLC__1SDV_20230823T154908_20230823T154935_050004_060418_521B.zip"
+    )
+    assert (
+        p.filename
+        == "S1A_IW_SLC__1SDV_20230823T154908_20230823T154935_050004_060418_521B.zip"
+    )
+    assert p.start_time == datetime(2023, 8, 23, 15, 49, 8)
+    assert p.stop_time == datetime(2023, 8, 23, 15, 49, 35)
+    assert p.relative_orbit == 57
+    assert p.polarization == "DV"
+    assert p.mission == "S1A"
+
+
+def test_sentinel_orbit():
+    p = SentinelOrbit(
+        "S1A_OPER_AUX_RESORB_OPOD_20230823T174849_V20230823T141024_20230823T172754"
+    )
+    assert (
+        p.filename
+        == "S1A_OPER_AUX_RESORB_OPOD_20230823T174849_V20230823T141024_20230823T172754"
+    )
+    assert p.orbit_type == "restituted"
+    assert p.start_time == datetime(2023, 8, 23, 14, 10, 24)
+    assert p.stop_time == datetime(2023, 8, 23, 17, 27, 54)

--- a/eof/tests/test_products.py
+++ b/eof/tests/test_products.py
@@ -1,5 +1,7 @@
-from eof.products import Sentinel, SentinelOrbit
 from datetime import datetime
+from pathlib import Path
+
+from eof.products import Sentinel, SentinelOrbit
 
 
 def test_sentinel():
@@ -28,3 +30,23 @@ def test_sentinel_orbit():
     assert p.orbit_type == "restituted"
     assert p.start_time == datetime(2023, 8, 23, 14, 10, 24)
     assert p.stop_time == datetime(2023, 8, 23, 17, 27, 54)
+
+
+def test_pathlib():
+    p1 = SentinelOrbit(
+        "S1A_OPER_AUX_RESORB_OPOD_20230823T174849_V20230823T141024_20230823T172754"
+    )
+    p2 = SentinelOrbit(
+        Path(
+            "S1A_OPER_AUX_RESORB_OPOD_20230823T174849_V20230823T141024_20230823T172754"
+        )
+    )
+    assert p1 == p2
+
+    p1 = Sentinel(
+        "S1A_IW_SLC__1SDV_20230823T154908_20230823T154935_050004_060418_521B.zip"
+    )
+    p2 = Sentinel(
+        Path("S1A_IW_SLC__1SDV_20230823T154908_20230823T154935_050004_060418_521B.zip")
+    )
+    assert p1 == p2

--- a/eof/tests/test_scihubclient.py
+++ b/eof/tests/test_scihubclient.py
@@ -37,8 +37,8 @@ def test_asf_client():
     dt = datetime.datetime(2020, 1, 1)
     mission = "S1A"
     asfclient = ASFClient()
-    urls = asfclient.get_download_urls([dt], [mission], orbit_type="restituted")
-    expected = "https://s1qc.asf.alaska.edu/aux_resorb/S1A_OPER_AUX_RESORB_OPOD_20200101T012955_V20191231T212606_20200101T004336.EOF"  # noqa
+    urls = asfclient.get_download_urls([dt], [mission], orbit_type="precise")
+    expected = "https://s1qc.asf.alaska.edu/aux_poeorb/S1A_OPER_AUX_POEORB_OPOD_20210315T155112_V20191230T225942_20200101T005942.EOF"  # noqa
     assert urls == [expected]
 
 

--- a/eof/tests/test_scihubclient.py
+++ b/eof/tests/test_scihubclient.py
@@ -1,6 +1,7 @@
 import datetime
 
 from eof.scihubclient import ScihubGnssClient
+from eof.products import Sentinel
 
 
 def test_query_orbit_by_dr():
@@ -12,3 +13,21 @@ def test_query_orbit_by_dr():
     r = results["9a844886-45e7-48ec-8bc4-5d9ea91f0553"]
     assert r["endposition"] > dt
     assert r["beginposition"] < dt
+
+
+def test_query_resorb_edge_case():
+    p = Sentinel(
+        "S1A_IW_SLC__1SDV_20230823T154908_20230823T154935_050004_060418_521B.zip"
+    )
+
+    client = ScihubGnssClient()
+
+    results = client.query_orbit_by_dt(
+        [p.start_time], [p.mission], orbit_type="restituted"
+    )
+    assert "702fa0e1-22db-4d20-ab26-0499f262d550" in results
+    r = results["702fa0e1-22db-4d20-ab26-0499f262d550"]
+    assert (
+        r["title"]
+        == "S1A_OPER_AUX_RESORB_OPOD_20230823T174849_V20230823T141024_20230823T172754"
+    )

--- a/eof/tests/test_scihubclient.py
+++ b/eof/tests/test_scihubclient.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from eof.scihubclient import ASFClient, ScihubGnssClient
 from eof.products import Sentinel
 
@@ -33,6 +35,7 @@ def test_query_resorb_edge_case():
     )
 
 
+@pytest.mark.skip("Local testing only for ASF")
 def test_asf_client():
     dt = datetime.datetime(2020, 1, 1)
     mission = "S1A"
@@ -42,6 +45,7 @@ def test_asf_client():
     assert urls == [expected]
 
 
+@pytest.mark.skip("Local testing only for ASF")
 def test_asf_full_url_list(monkeypatch, tmp_path):
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     asfclient = ASFClient()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sentineleof",
-    version="0.8.1",
+    version="0.8.2",
     author="Scott Staniewicz",
     author_email="scott.stanie@gmail.com",
     description="Download precise orbit files for Sentinel 1 products",


### PR DESCRIPTION
Fails to download any orbit for certain edge case RESORB files. This relaxes the padding so that shouldn't happen. Will need other accommodations for all of `s1reader`'s edge cases.