### PR TITLE
New option to prevent ~/.netrc modifications

### DIFF
--- a/eof/asf_client.py
+++ b/eof/asf_client.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import requests
 
-from ._auth import NASA_HOST, setup_netrc
 from ._select_orbit import T_ORBIT, ValidityError, last_valid_orbit
 from ._types import Filename
 from .log import logger
@@ -25,7 +24,6 @@ class ASFClient:
     eof_lists = {"precise": None, "restituted": None}
 
     def __init__(self, cache_dir: Optional[Filename] = None):
-        setup_netrc(host=NASA_HOST)
         self._cache_dir = cache_dir
 
     def get_full_eof_list(self, orbit_type="precise", max_dt=None):

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -8,6 +8,7 @@ import logging
 import click
 
 from eof import download, log
+from eof._auth import NASA_HOST, DATASPACE_HOST, setup_netrc
 
 
 @click.command()
@@ -63,6 +64,29 @@ from eof import download, log
     is_flag=True,
     help="Set logging level to DEBUG",
 )
+@click.option(
+    "--cdse-username",
+    help="Copernicus Data Space Ecosystem username. "
+    "If not provided the program asks for it",
+)
+@click.option(
+    "--cdse-password",
+    help="Copernicus Data Space Ecosystem password. "
+    "If not provided the program asks for it",
+)
+@click.option(
+    "--asf-username",
+    help="ASF username. If not provided the program asks for it",
+)
+@click.option(
+    "--asf-password",
+    help="ASF password. If not provided the program asks for it",
+)
+@click.option(
+    "--setup-netrc",
+    is_flag=True,
+    help="save credentials provided interactively in the ~/.netrc file if necessary",
+)
 def cli(
     search_path: str,
     save_dir: str,
@@ -72,6 +96,11 @@ def cli(
     orbit_type: str,
     force_asf: bool,
     debug: bool,
+    asf_user: str = "",
+    asf_password: str = "",
+    cdse_user: str = "",
+    cdse_password: str = "",
+    save_credantials: bool = False,
 ):
     """Download Sentinel precise orbit files.
 
@@ -82,6 +111,12 @@ def cli(
     With no arguments, searches current directory for Sentinel 1 products
     """
     log._set_logger_handler(level=logging.DEBUG if debug else logging.INFO)
+    dryrun = not save_credantials
+    if not (asf_user and asf_password):
+        setup_netrc(host=NASA_HOST, dryrun=dryrun)
+    if not (cdse_user and cdse_password):
+        setup_netrc(host=DATASPACE_HOST, dryrun=dryrun)
+
     download.main(
         search_path=search_path,
         save_dir=save_dir,
@@ -90,4 +125,8 @@ def cli(
         date=date,
         orbit_type=orbit_type,
         force_asf=force_asf,
+        asf_user=asf_user,
+        asf_password=asf_password,
+        cdse_user=cdse_user,
+        cdse_password=cdse_password,
     )

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -65,7 +65,7 @@ from eof._auth import NASA_HOST, DATASPACE_HOST, setup_netrc
     help="Set logging level to DEBUG",
 )
 @click.option(
-    "--cdse-username",
+    "--cdse-user",
     help="Copernicus Data Space Ecosystem username. "
     "If not provided the program asks for it",
 )
@@ -75,7 +75,7 @@ from eof._auth import NASA_HOST, DATASPACE_HOST, setup_netrc
     "If not provided the program asks for it",
 )
 @click.option(
-    "--asf-username",
+    "--asf-user",
     help="ASF username. If not provided the program asks for it",
 )
 @click.option(
@@ -83,7 +83,7 @@ from eof._auth import NASA_HOST, DATASPACE_HOST, setup_netrc
     help="ASF password. If not provided the program asks for it",
 )
 @click.option(
-    "--setup-netrc",
+    "--update-netrc",
     is_flag=True,
     help="save credentials provided interactively in the ~/.netrc file if necessary",
 )
@@ -98,9 +98,9 @@ def cli(
     debug: bool,
     asf_user: str = "",
     asf_password: str = "",
-    cdse_username: str = "",
+    cdse_user: str = "",
     cdse_password: str = "",
-    save_credentials: bool = False,
+    update_netrc: bool = False,
 ):
     """Download Sentinel precise orbit files.
 
@@ -111,11 +111,11 @@ def cli(
     With no arguments, searches current directory for Sentinel 1 products
     """
     log._set_logger_handler(level=logging.DEBUG if debug else logging.INFO)
-    dryrun = not save_credantials
+    dryrun = not update_netrc
     if not (asf_user and asf_password):
-        setup_netrc(host=NASA_HOST, dryrun=dryrun)
+        asf_user, asf_password = setup_netrc(host=NASA_HOST, dryrun=dryrun)
     if not (cdse_user and cdse_password):
-        setup_netrc(host=DATASPACE_HOST, dryrun=dryrun)
+        cdse_user, cdse_password = setup_netrc(host=DATASPACE_HOST, dryrun=dryrun)
 
     download.main(
         search_path=search_path,

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -100,7 +100,7 @@ def cli(
     asf_password: str = "",
     cdse_user: str = "",
     cdse_password: str = "",
-    save_credantials: bool = False,
+    save_credentials: bool = False,
 ):
     """Download Sentinel precise orbit files.
 

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -98,7 +98,7 @@ def cli(
     debug: bool,
     asf_user: str = "",
     asf_password: str = "",
-    cdse_user: str = "",
+    cdse_username: str = "",
     cdse_password: str = "",
     save_credentials: bool = False,
 ):

--- a/eof/download.py
+++ b/eof/download.py
@@ -46,9 +46,11 @@ def download_eofs(
     sentinel_file=None,
     save_dir=".",
     orbit_type="precise",
-    force_asf=False,
-    asf_user="",
-    asf_password="",
+    force_asf: bool = False,
+    asf_user: str = "",
+    asf_password: str = "",
+    cdse_user: str = "",
+    cdse_password: str = "",
 ):
     """Downloads and saves EOF files for specific dates
 
@@ -86,7 +88,7 @@ def download_eofs(
 
     # First, check that Scihub isn't having issues
     if not force_asf:
-        client = DataspaceClient()
+        client = DataspaceClient(username=cdse_user, password=cdse_password)
         # try to search on scihub
         if sentinel_file:
             query = client.query_orbit_for_product(sentinel_file, orbit_type=orbit_type)
@@ -101,7 +103,14 @@ def download_eofs(
 
     # For failures from scihub, try ASF
     if not dataspace_successful:
+        from ._auth import NASA_HOST, get_netrc_credentials
+
         logger.warning("Dataspace failed, trying ASF")
+
+        if not (asf_user and asf_password):
+            logger.debug("Get credentials form netrc")
+            asf_user, asf_password = get_netrc_credentials(NASA_HOST)
+
         asfclient = ASFClient()
         urls = asfclient.get_download_urls(orbit_dts, missions, orbit_type=orbit_type)
         # Download and save all links in parallel
@@ -231,9 +240,11 @@ def main(
     mission=None,
     date=None,
     orbit_type="precise",
-    force_asf=False,
-    asf_user="",
-    asf_password="",
+    force_asf: bool = False,
+    asf_user: str = "",
+    asf_password: str = "",
+    cdse_user: str = "",
+    cdse_password: str = "",
 ):
     """Function used for entry point to download eofs"""
 
@@ -275,4 +286,6 @@ def main(
         force_asf=force_asf,
         asf_user=asf_user,
         asf_password=asf_password,
+        cdse_user=cdse_user,
+        cdse_password=cdse_password,
     )


### PR DESCRIPTION
* userneme and password can always be provided explicitly file
* none of the API functions attempts to modify the ~/.netrc file
* ~/.netrc setup mover to the main function of the CLI