### PR TITLE
Support for annotation products

### DIFF
--- a/eof/products.py
+++ b/eof/products.py
@@ -126,7 +126,7 @@ class Sentinel(Base):
         r"(?P<beam>[\w\d]{2})_"
         r"(?P<product_type>[\w_]{3})"
         r"(?P<resolution_class>[FHM_])_"
-        r"(?P<product_level>[012])S"
+        r"(?P<product_level>[012])[SA]"
         r"(?P<polarization>[SDHV]{2})_"
         r"(?P<start_datetime>[T\d]{15})_"
         r"(?P<stop_datetime>[T\d]{15})_"


### PR DESCRIPTION
According to the official product naming convention for Sentinel-1 the [1] ther eis the possibility to have 'S' or 'A' as last character of the 'product_level' component of the products name.

The 'A' indicates annotation products that are not distributed to the final user, so in principle there should not be any need to support them. Never the less, I kindly ask to include this small patch to be able to support also annotation products.


[1] https://sentinels.copernicus.eu/web/sentinel/user-guides/sentinel-1-sar/naming-conventions