### PR TITLE
Support 2FA and any .netrc file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018-2020 Scott Staniewicz
+Copyright (c) 2024 Luc Hermitte, CS Group, support for double authentication on CDSE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Options:
                                   not provided the program asks for it
   --cdse-password TEXT            Copernicus Data Space Ecosystem password. If
                                   not provided the program asks for it
+  --cdse-2fa-token TEXT           Copernicus Data Space Ecosystem Two-Factor
+                                  Token. Optional, unless 2FA Authentification
+                                  has been enabled in user profile.
   --asf-user TEXT                 ASF username. If not provided the program
                                   asks for it
   --asf-password TEXT             ASF password. If not provided the program

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Options:
   --ask-password                  ask for passwords interactively if needed
   --update-netrc                  save credentials provided interactively in
                                   the ~/.netrc file if necessary
+  --netrc-file TEXT               Path to .netrc file. Default: ~/.netrc
   --max-workers INTEGER           Number of parallel downloads to run. Note
                                   that CDSE has a limit of 4
   --help                          Show this message and exit.

--- a/eof/_auth.py
+++ b/eof/_auth.py
@@ -90,7 +90,7 @@ def get_netrc_credentials(host: str, netrc_file: Optional[Filename] = None) -> t
     """Get username and password from netrc file for a given host."""
     netrc_file = netrc_file or "~/.netrc"
     netrc_file = Path(netrc_file).expanduser()
-    _logger.info(f"Using {netrc_file=!r}")
+    _logger.debug(f"Using {netrc_file=!r}")
     n = netrc.netrc(netrc_file)
     auth = n.authenticators(host)
     if auth is None:

--- a/eof/asf_client.py
+++ b/eof/asf_client.py
@@ -36,6 +36,7 @@ class ASFClient:
         cache_dir: Optional[Filename] = None,
         username: str = "",
         password: str = "",
+        netrc_file: Optional[Filename] = None,
     ):
         self._cache_dir = cache_dir
         if username and password:
@@ -46,7 +47,7 @@ class ASFClient:
             self._username = ""
             self._password = ""
             try:
-                self._username, self._password = get_netrc_credentials(NASA_HOST)
+                self._username, self._password = get_netrc_credentials(NASA_HOST, netrc_file)
             except FileNotFoundError:
                 logger.warning("No netrc file found.")
             except ValueError as e:

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -4,8 +4,10 @@ CLI tool for downloading Sentinel 1 EOF files
 from __future__ import annotations
 
 import logging
+from typing import Optional
 
 import click
+from ._types import Filename
 
 from eof import download, log
 from eof._auth import NASA_HOST, DATASPACE_HOST, setup_netrc
@@ -98,6 +100,10 @@ from eof._auth import NASA_HOST, DATASPACE_HOST, setup_netrc
     help="save credentials provided interactively in the ~/.netrc file if necessary",
 )
 @click.option(
+    "--netrc-file",
+    help="Path to .netrc file. Default: ~/.netrc",
+)
+@click.option(
     "--max-workers",
     type=int,
     default=3,
@@ -119,6 +125,7 @@ def cli(
     cdse_2fa_token: str = "",
     ask_password: bool = False,
     update_netrc: bool = False,
+    netrc_file: Optional[Filename] = None,
     max_workers: int = 3,
 ):
     """Download Sentinel precise orbit files.
@@ -133,9 +140,9 @@ def cli(
     if ask_password:
         dryrun = not update_netrc
         if not force_asf and not (cdse_user and cdse_password):
-            cdse_user, cdse_password = setup_netrc(host=DATASPACE_HOST, dryrun=dryrun)
+            cdse_user, cdse_password = setup_netrc(netrc_file=netrc_file, host=DATASPACE_HOST, dryrun=dryrun)
         if not (cdse_user and cdse_password) and not (asf_user and asf_password):
-            asf_user, asf_password = setup_netrc(host=NASA_HOST, dryrun=dryrun)
+            asf_user, asf_password = setup_netrc(netrc_file=netrc_file, host=NASA_HOST, dryrun=dryrun)
 
     download.main(
         search_path=search_path,
@@ -150,5 +157,6 @@ def cli(
         cdse_user=cdse_user,
         cdse_password=cdse_password,
         cdse_2fa_token=cdse_2fa_token,
+        netrc_file=netrc_file,
         max_workers=max_workers,
     )

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -75,6 +75,11 @@ from eof._auth import NASA_HOST, DATASPACE_HOST, setup_netrc
     "If not provided the program asks for it",
 )
 @click.option(
+    "--cdse-2fa-token",
+    help="Copernicus Data Space Ecosystem Two-Factor Token. "
+    "Optional, unless 2FA Authentification has been enabled in user profile.",
+)
+@click.option(
     "--asf-user",
     help="ASF username. If not provided the program asks for it",
 )
@@ -111,6 +116,7 @@ def cli(
     asf_password: str = "",
     cdse_user: str = "",
     cdse_password: str = "",
+    cdse_2fa_token: str = "",
     ask_password: bool = False,
     update_netrc: bool = False,
     max_workers: int = 3,
@@ -143,5 +149,6 @@ def cli(
         asf_password=asf_password,
         cdse_user=cdse_user,
         cdse_password=cdse_password,
+        cdse_2fa_token=cdse_2fa_token,
         max_workers=max_workers,
     )

--- a/eof/dataspace_client.py
+++ b/eof/dataspace_client.py
@@ -48,7 +48,7 @@ class DataspaceClient:
                 if DATASPACE_HOST not in e.args[0]:
                     raise e
                 logger.warning(
-                    f"No CDSE credentials found in netrc file. Please create one using {SIGNUP_URL}"
+                    f"No CDSE credentials found in netrc file {netrc_file!r}. Please create one using {SIGNUP_URL}"
                 )
 
         self._username = username

--- a/eof/download.py
+++ b/eof/download.py
@@ -126,7 +126,7 @@ def download_eofs(
         if not force_asf:
             logger.warning("Dataspace failed, trying ASF")
 
-        asf_client = ASFClient(username=asf_user, password=asf_password)
+        asf_client = ASFClient(username=asf_user, password=asf_password, netrc_file=netrc_file)
         urls = asf_client.get_download_urls(orbit_dts, missions, orbit_type=orbit_type)
         # Download and save all links in parallel
         pool = ThreadPool(processes=max_workers)

--- a/eof/download.py
+++ b/eof/download.py
@@ -28,10 +28,12 @@ import itertools
 import os
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
+from typing import Optional
 
 from dateutil.parser import parse
 from requests.exceptions import HTTPError
 
+from ._types import Filename
 from .asf_client import ASFClient
 from .dataspace_client import DataspaceClient
 from .log import logger
@@ -52,6 +54,7 @@ def download_eofs(
     cdse_user: str = "",
     cdse_password: str = "",
     cdse_2fa_token: str = "",
+    netrc_file: Optional[Filename] = None,
     max_workers: int = MAX_WORKERS,
 ) -> list[Path]:
     """Downloads and saves EOF files for specific dates
@@ -90,7 +93,7 @@ def download_eofs(
 
     # First, check that Scihub isn't having issues
     if not force_asf:
-        client = DataspaceClient(username=cdse_user, password=cdse_password, token_2fa=cdse_2fa_token)
+        client = DataspaceClient(username=cdse_user, password=cdse_password, token_2fa=cdse_2fa_token, netrc_file=netrc_file)
         if client._username and client._password:
             # try to search on scihub
             if sentinel_file:
@@ -212,6 +215,7 @@ def main(
     cdse_user: str = "",
     cdse_password: str = "",
     cdse_2fa_token: str = "",
+    netrc_file: Optional[Filename] = None,
     max_workers: int = MAX_WORKERS,
 ):
     """Function used for entry point to download eofs"""
@@ -257,5 +261,6 @@ def main(
         cdse_user=cdse_user,
         cdse_password=cdse_password,
         cdse_2fa_token=cdse_2fa_token,
+        netrc_file=netrc_file,
         max_workers=max_workers,
     )

--- a/eof/download.py
+++ b/eof/download.py
@@ -51,6 +51,7 @@ def download_eofs(
     asf_password: str = "",
     cdse_user: str = "",
     cdse_password: str = "",
+    cdse_2fa_token: str = "",
     max_workers: int = MAX_WORKERS,
 ) -> list[Path]:
     """Downloads and saves EOF files for specific dates
@@ -89,7 +90,7 @@ def download_eofs(
 
     # First, check that Scihub isn't having issues
     if not force_asf:
-        client = DataspaceClient(username=cdse_user, password=cdse_password)
+        client = DataspaceClient(username=cdse_user, password=cdse_password, token_2fa=cdse_2fa_token)
         if client._username and client._password:
             # try to search on scihub
             if sentinel_file:
@@ -210,6 +211,7 @@ def main(
     asf_password: str = "",
     cdse_user: str = "",
     cdse_password: str = "",
+    cdse_2fa_token: str = "",
     max_workers: int = MAX_WORKERS,
 ):
     """Function used for entry point to download eofs"""
@@ -254,5 +256,6 @@ def main(
         asf_password=asf_password,
         cdse_user=cdse_user,
         cdse_password=cdse_password,
+        cdse_2fa_token=cdse_2fa_token,
         max_workers=max_workers,
     )


### PR DESCRIPTION
This PR enables two things

### Two-Factor authentication on CDSE

Current implementation was not compatible with accounts where 2FA is enabled. The related API is described on https://documentation.dataspace.copernicus.eu/APIs/Token.html

As I wasn't sure how to know whether the account requires 2FA, I didn't try to ask interactively for the 2FA token at the last moment.

### Support `.netrc`  stored in any location

I don't store my `.netrc` directly under `$HOME`, but elsewhere. I've introduced the same option as the one supported by curl: `--netrc-file`

<del>I'd have loved to support encrypted `.netrc` -- which I use with git thanks to `git-netrc-credential`. Alas I'm afraid this will introduce an unwelcome dependency.</del>

Note that this will also permit to support encrypted `.netrc` files out-of-the box thanks to:

```bash
eof -d 2023-12-09 --netrc-file <(gpg -d ~/.config/.netrc.gpg | grep -v protocol)
```

## Finally

I haven't updated version number.