### PR TITLE
Support `--access-token` parameter for CDSE

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2018-2020 Scott Staniewicz
-Copyright (c) 2024 Luc Hermitte, CS Group, support for double authentication on CDSE
+Copyright (c) 2024 Luc Hermitte, CS Group, refactor authentication on CDSE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Options:
   --force-asf                     Force the downloader to search ASF instead
                                   of ESA.
   --debug                         Set logging level to DEBUG
+  --cdse-access-token TEXT        Copernicus Data Space Ecosystem access-
+                                  token. The access token can be generated
+                                  beforehand. See https://documentation.datasp
+                                  ace.copernicus.eu/APIs/Token.html
   --cdse-user TEXT                Copernicus Data Space Ecosystem username. If
                                   not provided the program asks for it
   --cdse-password TEXT            Copernicus Data Space Ecosystem password. If

--- a/eof/_auth.py
+++ b/eof/_auth.py
@@ -87,7 +87,12 @@ def _file_is_0600(filename: Filename):
 
 
 def get_netrc_credentials(host: str, netrc_file: Optional[Filename] = None) -> tuple[str, str]:
-    """Get username and password from netrc file for a given host."""
+    """
+    Get username and password from netrc file for a given host.
+
+    :return: username and password found for host in netrc_file
+    :postcondition: username and password are non empty strings.
+    """
     netrc_file = netrc_file or "~/.netrc"
     netrc_file = Path(netrc_file).expanduser()
     _logger.debug(f"Using {netrc_file=!r}")
@@ -98,6 +103,8 @@ def get_netrc_credentials(host: str, netrc_file: Optional[Filename] = None) -> t
     username, _, password = auth
     if username is None or password is None:
         raise ValueError(f"No username/password found for {host} in ~/.netrc")
+    if not username or not password:
+        raise ValueError(f"Empty username/password found for {host} in ~/.netrc")
     return username, password
 
 

--- a/eof/cli.py
+++ b/eof/cli.py
@@ -1,6 +1,7 @@
 """
 CLI tool for downloading Sentinel 1 EOF files
 """
+
 from __future__ import annotations
 
 import logging
@@ -67,6 +68,11 @@ from eof._auth import NASA_HOST, DATASPACE_HOST, setup_netrc
     help="Set logging level to DEBUG",
 )
 @click.option(
+    "--cdse-access-token",
+    help="Copernicus Data Space Ecosystem access-token. "
+    "The access token can be generated beforehand. See https://documentation.dataspace.copernicus.eu/APIs/Token.html",
+)
+@click.option(
     "--cdse-user",
     help="Copernicus Data Space Ecosystem username. "
     "If not provided the program asks for it",
@@ -120,6 +126,7 @@ def cli(
     debug: bool,
     asf_user: str = "",
     asf_password: str = "",
+    cdse_access_token: Optional[str] = None,
     cdse_user: str = "",
     cdse_password: str = "",
     cdse_2fa_token: str = "",
@@ -154,6 +161,7 @@ def cli(
         force_asf=force_asf,
         asf_user=asf_user,
         asf_password=asf_password,
+        cdse_access_token=cdse_access_token,
         cdse_user=cdse_user,
         cdse_password=cdse_password,
         cdse_2fa_token=cdse_2fa_token,

--- a/eof/dataspace_client.py
+++ b/eof/dataspace_client.py
@@ -227,7 +227,6 @@ def _construct_orbit_file_query(
     query_template = (
         "startswith(Name,'{mission_id}') and contains(Name,'{orbit_type}') "
         "and ContentDate/Start lt '{start_time}' and ContentDate/End gt '{stop_time}'"
-        # " and productType eq {orbit_type}"
     )
 
     # Format the query template using the values we were provided

--- a/eof/dataspace_client.py
+++ b/eof/dataspace_client.py
@@ -291,10 +291,12 @@ def query_orbit_file_service(query: str) -> list[dict]:
     return query_results
 
 
-def get_access_token(username, password, token_2fa) -> str:
+def get_access_token(username: str, password: str, token_2fa: Optional[str]) -> str:
     """Get an access token for the Copernicus Data Space Ecosystem (CDSE) API.
 
     Code from https://documentation.dataspace.copernicus.eu/APIs/Token.html
+
+    :precondition: username and password are non empty strings.
     """
     assert username and password, "Username and password values are expected!"
 

--- a/eof/download.py
+++ b/eof/download.py
@@ -21,6 +21,7 @@ https://earth.esa.int/documents/247904/349490/GMES_Sentinels_POD_Service_File_Fo
 
 See parsers for Sentinel file naming description
 """
+
 from __future__ import annotations
 
 import glob
@@ -51,6 +52,7 @@ def download_eofs(
     force_asf: bool = False,
     asf_user: str = "",
     asf_password: str = "",
+    cdse_access_token: Optional[str] = None,
     cdse_user: str = "",
     cdse_password: str = "",
     cdse_2fa_token: str = "",
@@ -93,8 +95,14 @@ def download_eofs(
 
     # First, check that Scihub isn't having issues
     if not force_asf:
-        client = DataspaceClient(username=cdse_user, password=cdse_password, token_2fa=cdse_2fa_token, netrc_file=netrc_file)
-        if client._username and client._password:
+        client = DataspaceClient(
+            access_token=cdse_access_token,
+            username=cdse_user,
+            password=cdse_password,
+            token_2fa=cdse_2fa_token,
+            netrc_file=netrc_file,
+        )
+        if client:
             # try to search on scihub
             if sentinel_file:
                 query = client.query_orbit_for_product(
@@ -212,6 +220,7 @@ def main(
     force_asf: bool = False,
     asf_user: str = "",
     asf_password: str = "",
+    cdse_access_token: Optional[str] = None,
     cdse_user: str = "",
     cdse_password: str = "",
     cdse_2fa_token: str = "",
@@ -258,6 +267,7 @@ def main(
         force_asf=force_asf,
         asf_user=asf_user,
         asf_password=asf_password,
+        cdse_access_token=cdse_access_token,
         cdse_user=cdse_user,
         cdse_password=cdse_password,
         cdse_2fa_token=cdse_2fa_token,


### PR DESCRIPTION
This new option is meant to simplify 2FA on CDSE.

### The issue

2FA token is extremely short lived -- it's refreshed every minute or so. This means that if we want to call `eof` manually several times, or to call it from a batched process, we'll need to update the 2FA token every time before calling `eof`.

### The proposed solution

If instead we manually acquire an _access token_, it's lifetime will be much longer (I've haven't exactly measured how much). 

This PR proposes a new option `--access-token` where we could feed the _access token_ instead of login/password[/2fa-token].

Or course the access token needs to be acquired manually thanks to the procedures described on https://documentation.dataspace.copernicus.eu/APIs/Token.html
